### PR TITLE
results page route added and search results displayed

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,9 +1,7 @@
 import React, { useEffect } from 'react'
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
-
 import { NavigationBar, Footer } from './components'
-import { FindJobs, HowItWorks, AboutUs, Homepage } from './pages'
-import FetchData from './components/FetchData';
+import { Results, FindJobs, HowItWorks, AboutUs, Homepage} from './pages'
 
 const App = () => {
   useEffect(() => {
@@ -20,9 +18,9 @@ const App = () => {
           <Route path="/find-jobs" element={<FindJobs />} />
           <Route path="/how-it-works" element={<HowItWorks />} />
           <Route path="/about-us" element={<AboutUs />} />
+          <Route path="/search-results" element={<Results />} />
         </Routes>
-        <FetchData/> {/* Used for demo purposes, can remove this later for actual implementation of data fetching */}
-
+        
       </Router>
       <Footer />
     </div>

--- a/client/src/components/FetchData.jsx
+++ b/client/src/components/FetchData.jsx
@@ -1,13 +1,16 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
+import { useLocation } from 'react-router-dom';
 
 function FetchData() {
-    const [message, setMessage] = useState('');
-    console.log('message: ', message);
+    const [jobs, setJobs] = useState([]);
+    const location = useLocation();
+
+    console.log('message: ', jobs);
     useEffect(() => { 
-        axios.get('http://localhost:8000/api/')
+        axios.get(`http://localhost:8000/api/scrape?keywords=${location.state.keyword}&location=${location.state.location}&limit=100`)
             .then( response => {
-                setMessage(response.data.greeting);
+                setJobs(response.data.results);
             })
             .catch(error => {
                 console.log(error);
@@ -16,7 +19,12 @@ function FetchData() {
 
         return (
             <div>
-                <h1>Message from the backend: {message}</h1>
+            {jobs.map((job, index) => (
+                <div key={index}>
+                    <h2>Title: {job.title}</h2>
+                    <p>Company: {job.company}</p>
+                </div>
+            ))}
             </div>
         )
 }

--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Button, TextInput } from 'flowbite-react'
 import { Hero } from '../components'
 import { FaSearch, FaMapPin } from 'react-icons/fa'
@@ -7,6 +8,12 @@ const LandingPage = () => {
   const [signedIn, setSignedIn] = useState(false)
   const [keyword, setKeyword] = useState('')
   const [location, setLocation] = useState('')
+
+  const navigate = useNavigate();
+  const handleSubmit = (e) => {
+      e.preventDefault();
+      navigate('/search-results', { state: { keyword, location } });
+  };
 
   const uploadResume = () => {}
   const signIn = () => {
@@ -33,7 +40,7 @@ const LandingPage = () => {
     <div className="flex flex-col items-center justify-center min-h-screen">
       <Hero />
       <div className="text-center mt-12">
-        <form className="flex flex-row items-center gap-2">
+        <form className="flex flex-row items-center gap-2" onSubmit={handleSubmit}>
           <TextInput
             id="keywords"
             icon={FaSearch}

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -2,5 +2,6 @@ import AboutUs from './AboutUs';
 import FindJobs from './FindJobs';
 import HowItWorks from './HowItWorks';
 import Homepage from './LandingPage'
+import Results from './Results';
 
-export { AboutUs, FindJobs, HowItWorks, Homepage }
+export { AboutUs, FindJobs, HowItWorks, Homepage, Results }


### PR DESCRIPTION
# Description
The following changes have been made:
- Results page added as an endpoint called **search-results**
- Event handler added to Landing page in order to store keyword and location user input. It then uses react router state and the FetchData component passes the info to the django endpoint /api/scrape
(`http://localhost:8000/api/scrape?keywords=${location.state.keyword}&location=${location.state.location}&limit=100`)

# Still Required
- Actual styling of the job search results + job descriptions
- input handling & security: need to ensure user enters expected data to avoid XSS, injection etc.

The page currently should look like this after entering a keyword and location: 
![Screenshot 2024-02-01 204641](https://github.com/michaelwlin/s_capstone_ai_jobs/assets/107959606/96d3c984-ec65-43f8-9688-0e3fe714e5c0)

