### PR TITLE
Changed port mapping in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     container_name: mongodb
     restart: always
     ports:
-      - 27017:27017
+      - 27018:27017
     volumes:
       - matchiq:/data/db
   


### PR DESCRIPTION
Changed mapping from 27017:27017 to 27018:27017
(Local Mongodb service runs on 27017, so anyone with a local mongodb service running that tried to connect to 27017 would not see any mongodb data inside the docker container)