### PR TITLE
Fix mongodb

### DIFF
--- a/django_be/matchiq_api/api/mongo_utils.py
+++ b/django_be/matchiq_api/api/mongo_utils.py
@@ -11,7 +11,7 @@ def save_to_mongodb(data):
     # client = MongoClient("mongodb://db:27017/matchiq")
     client = MongoClient(path)
 
-    collection = db["jobs"]
+    collection = client.matchiq.jobs
 
     try:
         collection.insert_many(data, ordered=False)

--- a/django_be/matchiq_api/api/mongo_utils.py
+++ b/django_be/matchiq_api/api/mongo_utils.py
@@ -5,10 +5,11 @@ from pymongo.errors import BulkWriteError
 
 
 def save_to_mongodb(data):
-    # load_dotenv()
-    # path = os.environ.get("DB_URL", "mongodb://db:27017/matchiq")
+    load_dotenv()
+    path = os.environ.get("DB_URI", "mongodb://db:27017/matchiq")
     print("saving to mongodb")
-    client = MongoClient("mongodb://db:27017/matchiq")
+    # client = MongoClient("mongodb://db:27017/matchiq")
+    client = MongoClient(path)
     db = client.get_database('matchiq')
 
     collection = db["jobs"]

--- a/django_be/matchiq_api/api/mongo_utils.py
+++ b/django_be/matchiq_api/api/mongo_utils.py
@@ -10,7 +10,6 @@ def save_to_mongodb(data):
     print("saving to mongodb")
     # client = MongoClient("mongodb://db:27017/matchiq")
     client = MongoClient(path)
-    db = client.get_database('matchiq')
 
     collection = db["jobs"]
 

--- a/django_be/matchiq_api/api/scrape_jobs.py
+++ b/django_be/matchiq_api/api/scrape_jobs.py
@@ -18,8 +18,9 @@ def retry_if_rate_limit_error(exception):
     return isinstance(exception, requests.HTTPError) and exception.response.status_code == 429
 
 
-@retry(retry_on_exception=retry_if_rate_limit_error, wait_fixed=5000, stop_max_attempt_number=3)
+@retry(retry_on_exception=retry_if_rate_limit_error, wait_fixed=3000, stop_max_attempt_number=3)
 def make_request(url):
+    logger.info(f"Making request to {url}")
     res = requests.get(url)
     res.raise_for_status()
     return res
@@ -40,7 +41,7 @@ def scrape_utility(keywords, location, limit):
             url_params, job)
 
         try:
-            logger.info("Scraping jobs...")
+            logger.info(f"Scraping job for {url}")
             res = make_request(url)
         except requests.RequestException as e:
             logger.error(f"Error making request to {url}: {e}")
@@ -56,7 +57,7 @@ def scrape_utility(keywords, location, limit):
 
 def get_description(url):
     try:
-        logger.info("Scraping description...")
+        logger.info(f"Scraping description for {url}")
         res = make_request(url)
     except requests.RequestException as e:
         logger.error(f"Error making request to {url}: {e}")


### PR DESCRIPTION
TL;DR - add the database name ("matchiq" without quotes) to the end of your .env files

This branch is meant to resolve the issue of not being able to see the jobs collection data when going to localhost:4000/api/jobs - this issue was due to the mongo_utils.py file specifying a connection to the matchiq database, while nothing else in our code was specifically pointing to that same database. The variable used to connecto to our MongoDB database, DB_URI, was pointing to our MongoDB account without specifying a database, which meant it was defaulting to a database called "test". This is also why the new user registration page was creating users under the "test" database. Appending "matchiq" to the end of our .env files will resolve this issue. I removed the line that defines the db since it will be redundant after the .env file change.